### PR TITLE
Split Error

### DIFF
--- a/src/pydukeenergy/api.py
+++ b/src/pydukeenergy/api.py
@@ -159,7 +159,7 @@ class DukeEnergy(object):
             soup = BeautifulSoup(response.text, "html.parser")
             meter_data = json.loads(soup.find("duke-dropdown", {"id": "usageAnalysisMeter"})["items"])
             _LOGGER.debug(str(meter_data))
-            for meter in meter_data:
+            for meter in meter_data[:1]:
                 meter_type, meter_id = meter["text"].split(" - ")
                 meter_start_date = meter["CalendarStartDate"]
                 self.meters.append(Meter(self, meter_type, meter_id, meter_start_date, self.update_interval))


### PR DESCRIPTION
Getting ValueError: not enough values to unpack (expected 2, got 1) due to the data pulled from duke having an extra meter with no data.

Here's the data that's associated with meter_data:
```
[{'id': 1, 'value': 'ELECTRIC - 0000000', 'text': 'ELECTRIC - 0000000', 'type': None, 'certified': False, 'CalendarStartDate': '04/02/2018', 'CalendarEndDate': '12/31/9999', 'CalendarCurrentDate': '07/21/2018', 'graphItems': [{'id': 1, 'value': 'DailyEnergy', 'text': 'Daily Energy and Avg. ', 'periodItems': [{'id': 1, 'value': 'Billing Cycle', 'text': 'Billing Cycle', 'selected': True}, {'id': 2, 'value': 'Month', 'text': 'Month', 'selected': False}, {'id': 3, 'value': 'Week', 'text': 'Week', 'selected': False}]}, {'id': 2, 'value': 'averageEnergyByDayOfWeek', 'text': 'Avg. by Day-of-Week ', 'periodItems': [{'id': 1, 'value': 'Billing Cycle', 'text': 'Billing Cycle', 'selected': True}, {'id': 2, 'value': 'Month', 'text': 'Month', 'selected': False}]}, {'id': 3, 'value': 'hourlyEnergyUse', 'text': 'Hourly Energy Usage ', 'periodItems': [{'id': 1, 'value': 'Week', 'text': 'Week', 'selected': True}, {'id': 2, 'value': 'Day', 'text': 'Day', 'selected': False}]}],
'LargeBusiness': False}, {'id': 1, 'value': None, 'text': '-', 'type': None, 'certified': False, 'CalendarStartDate': None, 'CalendarEndDate': None, 'CalendarCurrentDate': None, 'graphItems': None, 'LargeBusiness': False}]
```
It seems it ignores ['ELECTRIC', '0000000'] and tries to assign ['-'] to meter_type and meter_id.
Changed line 162 to `for meter in meter_data[:1]:` to correct the issue.

Not sure if this effects anything else like having multiple meters on the account.